### PR TITLE
Removed "brp-extract-appdata", dropped in Factory

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -19,7 +19,6 @@ RUN zypper --non-interactive install --no-recommends \
   automake \
   boost-devel \
   brp-check-suse \
-  brp-extract-appdata \
   build \
   ccache \
   doxygen \


### PR DESCRIPTION
## Problem

- The image does not build in OBS because of `unresolvable: nothing provides brp-extract-appdata` error
- See https://build.opensuse.org/package/show/YaST:Head/ci-libstorage-ng-container
- The package has been dropped from Factory/Tumbleweed ([delete request](https://build.opensuse.org/request/show/959999))

## Solution

- Remove the package from the list
