### PR TITLE
Skip building the image when submitting to OBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 [![CI](https://github.com/yast/ci-libstorage-ng-container/actions/workflows/ci.yml/badge.svg?branch=master)](
 https://github.com/yast/ci-libstorage-ng-container/actions/workflows/ci.yml)
+[![OBS](https://github.com/yast/ci-libstorage-ng-container/actions/workflows/submit.yml/badge.svg)](https://github.com/yast/ci-libstorage-ng-container/actions/workflows/submit.yml)
 
 This git repository contains the configuration used to build the docker
-image used for [TravisCI](https://travis-ci.org/).
+image used for [GitHub Actions](https://docs.github.com/en/actions).
 The resulting docker image is available at https://registry.opensuse.org/.
 
 ## Automatic Rebuilds
 
 - The image is rebuilt whenever a commit it pushed to the `master` branch.
-- The [yast-ci-libstorage-ng-container-master](
-  https://ci.opensuse.org/view/Yast/job/yast-ci-libstorage-ng-container-master/)
-  Jenkins job copies the configuration to the [YaST:Head/ci-libstorage-ng-container](
+- The [submit.yml](./.github/workflows/submit.yml)
+  GitHub Action commits the configuration to the [YaST:Head/ci-libstorage-ng-container](
   https://build.opensuse.org/package/show/YaST:Head/ci-libstorage-ng-container)
   OBS project
 - The OBS tracks the dependencies and rebuilds the image if any dependant package

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,6 @@ end
 # do not create a tarball, this project builds a Docker container
 Rake::Task["tarball"].clear_actions
 
-# building at Jenkins does not work for some reason, disable it for now
-Rake::Task["osc:build"].clear if ENV["JENKINS_HOME"]
+# building at Jenkins/GitHub Actions does not work, disable it for now
+Rake::Task["osc:build"].clear if ENV["JENKINS_HOME"] || ENV["CI"]
 


### PR DESCRIPTION
Similar to https://github.com/yast/ci-cpp-container/pull/12

## Problem

- Building the Docker image fails when running `osc build` inside a docker container

## Solution

- The Docker image is built with plain `docker build` instead of `osc build`
- See [.github/workflows/ci.yml](https://github.com/yast/ci-cpp-container/blob/master/.github/workflows/ci.yml) for more details
- Updated documentation

